### PR TITLE
xf86-input-evdev: version bumped to 2.7.3.

### DIFF
--- a/driver/xf86-input-evdev/DETAILS
+++ b/driver/xf86-input-evdev/DETAILS
@@ -1,12 +1,12 @@
           MODULE=xf86-input-evdev
-         VERSION=2.7.1
+         VERSION=2.7.3
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=$XORG_URL/individual/driver
-      SOURCE_VFY=sha1:15847129d7d48bcdba56eae8f60421170aea496d
+      SOURCE_VFY=sha1:57adaafd29d59b3685c923342717e767a0323474
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060303
-         UPDATED=20120727
+         UPDATED=20120815
            SHORT="An input driver"
 
 cat << EOF


### PR DESCRIPTION
Bugfixes release.
