### PR TITLE
mesa-lib: make configure messages appear only when unconfigured

### DIFF
--- a/lib/mesa-lib/CONFIGURE
+++ b/lib/mesa-lib/CONFIGURE
@@ -53,7 +53,7 @@ if ! grep -q "MESADRIVER=" $MODULE_CONFIG; then
   set_module_config MESADRIVER "$MESADRIVER"
 fi
 
-if [[ -z "`get_module_config GALLIUM`" ]]; then
+if [[ -z "$(get_module_config CONFIGURED)" ]]; then
   message "${MESSAGE_COLOR}Gallium is an alternative to DRI and needed to do 3D acceleration on"
   message "nouveau, radeon(-hd), ati or Intel GMA (Poulsbo/Cedar Trail). However, Gallium is not"
   message "performing on Intel GENX graphics (Any onboard Corei3/5/7, G25/33/45, pinetrail gfx"
@@ -91,3 +91,5 @@ else
 fi
 mquery TEXTURE_FLOAT "Enable patented texture-float? (if this patent is valid in your country choose N)" n "--enable-texture-float" "--disable-texture-float"
 mquery ENABLE_GLX_TLS "Enable glx-tls? (lin -r xorg-server also)" y "--enable-glx-tls" "--disable-glx-tls"
+
+set_module_config CONFIGURED y


### PR DESCRIPTION
At the moment these messages also appear when installing a module that
depends on mesa-lib (and mesa-lib is already installed), because the
CONFIGURE file is parsed.
