### PR TITLE
xdg-utils: create required standard XDG folders

### DIFF
--- a/utils/xdg-utils/BUILD
+++ b/utils/xdg-utils/BUILD
@@ -1,0 +1,3 @@
+default_build &&
+
+mkdir -p /usr/share/applications /usr/share/mime /usr/share/desktop-directories

--- a/utils/xdg-utils/DETAILS
+++ b/utils/xdg-utils/DETAILS
@@ -5,7 +5,7 @@
       SOURCE_VFY=sha1:5bd5e2fe10e3055ccec347e8608476fab2d3eaca
         WEB_SITE=http://portland.freedesktop.org/wiki/XdgUtils
          ENTERED=20061012
-         UPDATED=20110927
+         UPDATED=20130630
            SHORT="tools to help applications to easily integrate with the free desktop standards"
 
 cat << EOF


### PR DESCRIPTION
xdg-desktop-menu fails to work if /usr/share/desktop-directories does not
exist - even if it should only install files to applications/! Stupid
design...
