### PR TITLE
xorg-server: rebuild drivers in POST_INSTALL

### DIFF
--- a/xorg-server/POST_INSTALL
+++ b/xorg-server/POST_INSTALL
@@ -1,0 +1,6 @@
+# make sure drivers have the same ABI version as the server
+for driver in $(list_modules xorg/driver); do
+   if module_installed "$driver"; then
+      lin -c "$driver"
+   fi
+done


### PR DESCRIPTION
Without this rebuild, we risk to have X modules with outdated ABI versions.
This is not detected by `lunar fix` and already broke my X twice.

Don't remove this unless you provide a different fix for this defect.
