### PR TITLE
xf86-video-vesa: fix build

### DIFF
--- a/driver/xf86-video-vesa/DETAILS
+++ b/driver/xf86-video-vesa/DETAILS
@@ -1,8 +1,12 @@
           MODULE=xf86-video-vesa
          VERSION=2.3.2
           SOURCE=$MODULE-$VERSION.tar.bz2
+         # obsolete with next release
+         SOURCE2=xf86-video-vesa-2.3.2-no-mibstore.patch
       SOURCE_URL=$XORG_URL/individual/driver
+     SOURCE2_URL=$PATCH_URL
       SOURCE_VFY=sha1:d49a57de24e7923bf17270084ce91ecf2feb4286
+     SOURCE2_VFY=sha1:e48804306b05d54603d9107d61e5f74d60ec9d3d
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060120

--- a/driver/xf86-video-vesa/PRE_BUILD
+++ b/driver/xf86-video-vesa/PRE_BUILD
@@ -1,0 +1,3 @@
+default_pre_build &&
+
+patch_it $SOURCE2 1


### PR DESCRIPTION
This patch is already upstream. There's simply no new version yet, so we'll
patch this locally.
