### PR TITLE
xf86-video-intel: version bumped to 2.99.907

### DIFF
--- a/driver/xf86-video-intel/BUILD
+++ b/driver/xf86-video-intel/BUILD
@@ -1,12 +1,5 @@
-(
+. /etc/profile.d/x11r7.rc &&
 
-#  patch_it $SOURCE2 1  &&
-
-  . /etc/profile.d/x11r7.rc &&
-
-#  OPTS+=" --with-xserver-source=`pwd -P`" &&
-  CFLAGS="$CFLAGS -I`pwd -P`/src/parser" &&
-  OPTS=" $OPTS --enable-sna --enable-vmap " &&
-  default_build
-
-) > $C_FIFO 2>&1
+CFLAGS+=" -I`pwd -P`/src/parser" &&
+OPTS+=" --enable-sna" &&
+default_build

--- a/driver/xf86-video-intel/DETAILS
+++ b/driver/xf86-video-intel/DETAILS
@@ -1,12 +1,12 @@
           MODULE=xf86-video-intel
-         VERSION=2.21.15
+         VERSION=2.99.907
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=$XORG_URL/individual/driver
-      SOURCE_VFY=sha1:6952e6e1deff1c4580ddee472dbc2223c3248d0f
+      SOURCE_VFY=sha1:5759feef71aa09c82111090ff163fa5ba94406f6
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060124
-         UPDATED=20130822
+         UPDATED=20140118
            SHORT="The X.Org video driver for Intel based cards"
 
 cat << EOF


### PR DESCRIPTION
Should be ABI compatible with xorg-server 1.15
