### PR TITLE
mesa-lib: version bumped to 10.5.5.

### DIFF
--- a/lib/mesa-lib/BUILD
+++ b/lib/mesa-lib/BUILD
@@ -3,16 +3,14 @@
   if [[ $GALLIUM == y ]]; then
     # Mesa Gallium mklib breaks build when linker flags are set
     bad_flags linker &&
-
     OPTS+=" --with-gallium-drivers=swrast,$(echo $GALLIUMDRIVER | sed s/\ /,/g)" &&
-
     OPTS+=" --enable-gallium-egl --enable-gallium-osmesa"
   else
     OPTS+=" --enable-egl --enable-osmesa --with-gallium-drivers="
   fi  &&
 
   OPTS+=" --with-dri-drivers=swrast,$(echo $MESADRIVER | sed s/\ /,/g)" &&
-
   OPTS+=" --enable-xa --enable-gles1 --enable-gles2 --enable-gbm --with-egl-platforms=drm,x11" &&
+  OPTS+=" --enable-dri --enable-glx --enable-texture-float --enable-shared-glapi"
 
   default_build

--- a/lib/mesa-lib/DEPENDS
+++ b/lib/mesa-lib/DEPENDS
@@ -5,14 +5,18 @@ depends dri2proto
 depends dri3proto
 depends libdrm
 depends makedepend
-depends libXi
 depends libXdamage
 depends libXt
 depends libXxf86vm
 depends libxshmfence
+depends libva
 depends presentproto
+depends glproto
+depends Mako
+depends nettle
 
 optional_depends "libvdpau" "--enable-vdpau" "--disable-vdpau" "vdpau hw acceleration"
 optional_depends "libXvMC"  "--enable-xvmc"  "--disable-xvmc"  "XvMC hw acceleration"
+
 optional_depends "llvm"     ""  ""  "llvm is required when building Gallium drivers"
 optional_depends "elfutils" ""  "" "elfutils is required when building radeonsi driver"

--- a/lib/mesa-lib/DETAILS
+++ b/lib/mesa-lib/DETAILS
@@ -1,12 +1,12 @@
            MODULE=mesa-lib
-          VERSION=10.4.7
-           SOURCE=MesaLib-$VERSION.tar.bz2
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/Mesa-$VERSION
+          VERSION=10.5.5
+           SOURCE=mesa-$VERSION.tar.xz
+ SOURCE_DIRECTORY=$BUILD_DIRECTORY/mesa-$VERSION
        SOURCE_URL=ftp://ftp.freedesktop.org/pub/mesa/$VERSION/
-       SOURCE_VFY=sha256:2c351c98671f9a7ab3fd9c601bb7a255801b1580f5dd0992639f99152801b0d2
+       SOURCE_VFY=sha256:4ac4e4ea3414f1cadb1467f2f173f9e56170d31e8674f7953a46f0549d319f28
          WEB_SITE=http://www.mesa3d.org
           ENTERED=20060215
-          UPDATED=20150324
+          UPDATED=20150512
             SHORT="Mesa 3D library"
 
 cat << EOF


### PR DESCRIPTION
It needs llvm 3.6.0 (there is a PR for other repo).