### PR TITLE
libdrm: version bumped to 2.4.62.

### DIFF
--- a/lib/libdrm/DETAILS
+++ b/lib/libdrm/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libdrm
-         VERSION=2.4.61
+         VERSION=2.4.62
           SOURCE=$MODULE-$VERSION.tar.bz2
       SOURCE_URL=http://dri.freedesktop.org/libdrm
-      SOURCE_VFY=sha256:8b549092c8961a393a7e1d9a1bccddcea8e2af67c0d7d7c67babb9fc3b47699c
+      SOURCE_VFY=sha256:
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://dri.freedesktop.org
          ENTERED=20061017
-         UPDATED=20150507
+         UPDATED=20150630
            SHORT="The userspace interface to kernel DRM services"
 
 cat << EOF


### PR DESCRIPTION
It needs llvm 3.6.1 (it's a PR in other repo for it).