### PR TITLE
mesa-lib: Adding optional_depends for wayland. kde and especially plasma

### DIFF
--- a/lib/mesa-lib/DEPENDS
+++ b/lib/mesa-lib/DEPENDS
@@ -14,6 +14,7 @@ depends presentproto
 depends Mako
 depends nettle
 
+optional_depends wayland  "" "" "This is needed by various components of Plasma"
 optional_depends libvdpau "--enable-vdpau" "--disable-vdpau" "vdpau hw acceleration"
 optional_depends libXvMC  "--enable-xvmc"  "--disable-xvmc"  "XvMC hw acceleration"
 


### PR DESCRIPTION
are making a slow walk towards this being the default. So we need it here
when you compile kde-workspace and plasma. There might be a few other kde
modules that can use this but kde-workspace is the one I know of for now
and of course plasma.

Unfortunately mesa does not provide any switches.