### PR TITLE
mesa-lib: bump to 11.2.2. Changing up the logic for wayland, as it wa…

### DIFF
--- a/lib/mesa-lib/BUILD
+++ b/lib/mesa-lib/BUILD
@@ -9,10 +9,10 @@ else
   OPTS+=" --enable-egl --enable-osmesa --with-gallium-drivers="
 fi  &&
 
-OPTS+=" --with-egl-platforms=drm,x11" &&
-
-if in_depends $MODULE wayland; then
-  OPTS+=",wayland"
+if module_installed wayland; then
+  OPTS+=" --with-egl-platforms=drm,x11,wayland"
+   else
+  OPTS+=" --with-egl-platforms=drm,x11"
 fi &&
 
 OPTS+=" --enable-dri   \

--- a/lib/mesa-lib/BUILD
+++ b/lib/mesa-lib/BUILD
@@ -9,7 +9,7 @@ else
   OPTS+=" --enable-egl --enable-osmesa --with-gallium-drivers="
 fi  &&
 
-if module_installed wayland; then
+if in_depends $MODULE wayland; then
   OPTS+=" --with-egl-platforms=drm,x11,wayland"
    else
   OPTS+=" --with-egl-platforms=drm,x11"

--- a/lib/mesa-lib/DEPENDS
+++ b/lib/mesa-lib/DEPENDS
@@ -41,3 +41,6 @@ optional_depends libgcrypt \
                  "for SHA1 implementation"
 
 optional_depends libXxf86misc "" "" "for some old binary compatibility" n
+
+optional_depends wayland "" "" "for wayland windowing protocol support"
+

--- a/lib/mesa-lib/DETAILS
+++ b/lib/mesa-lib/DETAILS
@@ -1,12 +1,12 @@
            MODULE=mesa-lib
-          VERSION=11.2.1
+          VERSION=11.2.2
            SOURCE=mesa-$VERSION.tar.xz
  SOURCE_DIRECTORY=$BUILD_DIRECTORY/mesa-$VERSION
        SOURCE_URL=ftp://ftp.freedesktop.org/pub/mesa/$VERSION/
-       SOURCE_VFY=sha256:a65207e9ae5c5f1c29f863c6a2cc98a7ab99762a24b82a248337f0ea9cfce01b
+       SOURCE_VFY=sha256:40e148812388ec7c6d7b6657d5a16e2e8dabba8b97ddfceea5197947647bdfb4
          WEB_SITE=http://www.mesa3d.org
           ENTERED=20060215
-          UPDATED=20160418
+          UPDATED=20160521
             SHORT="Mesa 3D library"
 
 cat << EOF


### PR DESCRIPTION
…s wayland was not

being added to the egl platforms. First tried fixing the spacing issue with += in the
if logic, no go. Then tried making the OPTS in the if logic to be --with-egl-platforms=drm,x11,wayland,
no go. So let's do it this way and look for it being installed.