### PR TITLE
NVIDIA: Bumpt x86_64 to 390.25. This my explain the random hard syste…

### DIFF
--- a/driver/NVIDIA/DETAILS.x86_64
+++ b/driver/NVIDIA/DETAILS.x86_64
@@ -1,5 +1,5 @@
           MODULE=NVIDIA
-         VERSION=390.12
+         VERSION=390.25
           SOURCE=NVIDIA-Linux-x86_64-$VERSION-no-compat32.run
          SOURCE2=nvidia-settings-$VERSION.tar.bz2
          SOURCE3=nvidia-installer-$VERSION.tar.bz2
@@ -14,15 +14,15 @@ SOURCE_DIRECTORY=$BUILD_DIRECTORY/NVIDIA-Linux-x86_64-$VERSION-no-compat32
   SOURCE3_URL[1]=http://cgit.freedesktop.org/~aplattner/nvidia-installer/snapshot
   SOURCE4_URL[1]=http://cgit.freedesktop.org/~aplattner/nvidia-xconfig/snapshot
      SOURCE5_URL=$PATCH_URL
-      SOURCE_VFY=sha256:68c744abc7f42eaa9e640d90ecd3c7691a74b84584b83b776488ef1916f8eb43
-     SOURCE2_VFY=sha256:4696be7541fa83587f605cacb5f04906d33e300b2cf346c25159344987b44358
-     SOURCE3_VFY=sha256:1f546f1da595b9d94a7f3ebd0b6dcfd5a32dfca69c55680d583c627fe1a75a50
-     SOURCE4_VFY=sha256:cd6fce21a70cdac02ea895d71e44066e7f918d08925e6d67c03928f7eaa76b68
+      SOURCE_VFY=sha256:02263bc81b66e68fc8224447b249f4f0ca4ae201c467e236d917be2fe187f3d6
+     SOURCE2_VFY=sha256:c79bb974e3e716f3448088d72201bb9cfeec8d13ea8dbe5376439bf191c90bca
+     SOURCE3_VFY=sha256:2a9994a4af3e083f4245a018eda1096fcfda06e9ec55cbf3e786fa53ffabdc35
+     SOURCE4_VFY=sha256:1fbcc43094d2a2dc64c8906e38c103b57d7d797e3bff50bcefb2409e8df49ed1
      SOURCE5_VFY=sha256:664b565f0863441192b52cdd50a1126da8d696069c63d391bd8cdeb91ee3cf48
         WEB_SITE=http://www.nvidia.com/
          LICENSE="proprietary"
          ENTERED=20030804
-         UPDATED=20180109
+         UPDATED=20180216
            SHORT="X11 NVIDIA binary driver for Geforce 6/7/8/9/GT2xx"
 
 cat << EOF


### PR DESCRIPTION
…m locks

I"ve been experiencing;

"Fixed a regression introduced in 390.12 that caused occasional hangs and hard lockup
messages in the system log when screen transformations are in use."