### PR TITLE
xf86-input-evdev

### DIFF
--- a/driver/xf86-input-evdev/BUILD
+++ b/driver/xf86-input-evdev/BUILD
@@ -4,4 +4,5 @@ autoreconf -fi &&
 
 default_build &&
 
+mkdir -p /etc/X11/xorg.conf.d
 install -m644 $SCRIPT_DIRECTORY/11-evdev-mouse.conf /etc/X11/xorg.conf.d/


### PR DESCRIPTION
Fix BUILD script in case /etc/X11/xorg.conf.d is not present