### PR TITLE
xf86-video-amdgpu GCC fix

### DIFF
--- a/driver/xf86-video-amdgpu/BUILD
+++ b/driver/xf86-video-amdgpu/BUILD
@@ -1,3 +1,4 @@
 . /etc/profile.d/x11r7.rc &&
 
+CFLAGS=" -fcommon"
 default_build


### PR DESCRIPTION
added -fcommon to BUILD, to compile with GCC 10.

This should be considered temporary - a patch or version bump will probably be made quickly.