### PR TITLE
fontconfig - patch for xfce

### DIFF
--- a/fontconfig/patch.d/5f12f564f8748deaa603adb7a4b8f616b6390ad4.patch
+++ b/fontconfig/patch.d/5f12f564f8748deaa603adb7a4b8f616b6390ad4.patch
@@ -1,0 +1,43 @@
+From 5f12f564f8748deaa603adb7a4b8f616b6390ad4 Mon Sep 17 00:00:00 2001
+From: Keith Packard <keithp@keithp.com>
+Date: Wed, 17 Oct 2018 21:15:47 -0700
+Subject: [PATCH] Do not remove UUID file when a scanned directory is empty
+
+Because FcDirCacheDeleteUUID does not reset the modification time on
+the directory, and because FcDirCacheRead unconditionally creates the
+UUID file each time it is run, any empty directory in the cache will
+get its timestamp changed each time the cache for that directory is
+read.
+
+Instead, just leave the UUID file around as it is harmless.
+
+The alternative would be to only create the UUID file after the cache
+has been created and the directory has been discovered to be
+non-empty, but that would delay the creation of the UUID file.
+
+Signed-off-by: Keith Packard <keithp@keithp.com>
+---
+ src/fcdir.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/src/fcdir.c b/src/fcdir.c
+index 93f220c3..bfcdf956 100644
+--- a/src/fcdir.c
++++ b/src/fcdir.c
+@@ -421,13 +421,6 @@ FcDirCacheRead (const FcChar8 *dir, FcBool force, FcConfig *config)
+     /* Not using existing cache file, construct new cache */
+     if (!cache)
+ 	cache = FcDirCacheScan (dir, config);
+-    if (cache)
+-    {
+-	FcFontSet *fs = FcCacheSet (cache);
+-
+-	if (cache->dirs_count == 0 && (!fs || fs->nfont == 0))
+-	    FcDirCacheDeleteUUID (dir, config);
+-    }
+ 
+     return cache;
+ }
+-- 
+GitLab
+


### PR DESCRIPTION
Xfce-settingsd and fontconfig have a conflict that causes constant cpu spikes and disk access.

From the patch description:
"Because FcDirCacheDeleteUUID does not reset the modification time on
the directory, and because FcDirCacheRead unconditionally creates the
UUID file each time it is run, any empty directory in the cache will
get its timestamp changed each time the cache for that directory is
read."

- This timestamp change causes xfce4-settingsd to re-check the directory every time an application is opened. This updates the timestamp.
- fontconfig is re-activated, and re-checks the directory, and updates the timestamp. 
- Repeat forever.

This patch is from a commit that's been accepted into upstream, and is already in the 2.13.9* testing versions.
It will be part of the new version of fontconfig (whenever that happens).