### PR TITLE
iceauth: version bumped to 1.0.9

### DIFF
--- a/app/iceauth/DETAILS
+++ b/app/iceauth/DETAILS
@@ -1,12 +1,12 @@
           MODULE=iceauth
-         VERSION=1.0.8
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.0.9
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/app/
-      SOURCE_VFY=sha256:e6ee213a217265cc76050e4293ea70b98c32dce6505c6421227efbda62ab60c6
+      SOURCE_VFY=sha256:2cb9dfcb545683af77fb1029bea3fc52dcc8a0666f7b8b2d7373b6ed4c408c05
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060210
-         UPDATED=20180307
+         UPDATED=20220428
            SHORT="ICE authority file utility"
 
 cat << EOF


### PR DESCRIPTION
Upstream changed archive format from bzip2 to xz. gzip still available.