### PR TITLE
setxkbmap: version bumped to 1.3.3

### DIFF
--- a/app/setxkbmap/BUILD
+++ b/app/setxkbmap/BUILD
@@ -1,3 +1,4 @@
 . /etc/profile.d/x11r7.rc &&
 
 default_build
+

--- a/app/setxkbmap/DEPENDS
+++ b/app/setxkbmap/DEPENDS
@@ -1,1 +1,2 @@
 depends libxkbfile
+

--- a/app/setxkbmap/DETAILS
+++ b/app/setxkbmap/DETAILS
@@ -1,12 +1,12 @@
           MODULE=setxkbmap
-         VERSION=1.3.2
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.3.3
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/app/
-      SOURCE_VFY=sha256:8ff27486442725e50b02d7049152f51d125ecad71b7ce503cfa09d5d8ceeb9f5
+      SOURCE_VFY=sha256:b560c678da6930a0da267304fa3a41cc5df39a96a5e23d06f14984c87b6f587b
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20070216
-         UPDATED=20190715
+         UPDATED=20220429
            SHORT="Set the keyboard using the X Keyboard Extension"
 
 cat << EOF


### PR DESCRIPTION
Upstream also changed the bzip2 archive for the xz format here.