### PR TITLE
appres: version bumped to 1.0.6

### DIFF
--- a/app/appres/DETAILS
+++ b/app/appres/DETAILS
@@ -1,12 +1,12 @@
           MODULE=appres
-         VERSION=1.0.5
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.0.6
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/app/
-      SOURCE_VFY=sha256:ffad893712c81943b919e3cbfe46fc65259cc0d9eb96d5e658670e3fbb265928
+      SOURCE_VFY=sha256:8b2257e2a0a1ad8330323aec23f07c333075d7fe4e6efd88e0c18fba8223590b
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20070216
-         UPDATED=20180307
+         UPDATED=20220508
            SHORT="List X application resource database"
 
 cat << EOF


### PR DESCRIPTION
Upstream changed tarball compression from bz2 to xz