### PR TITLE
NVIDIA: Fixing typo in BUILD, arch should be x86_64 and adding egl-wa…

### DIFF
--- a/driver/NVIDIA/BUILD
+++ b/driver/NVIDIA/BUILD
@@ -1,4 +1,7 @@
-if [[ `arch` == x68_64 ]]; then
+
+CFLAGS+=" -fcommon"
+
+if [[ `arch` == x86_64 ]]; then
   ARCH=`arch`
 else
   ARCH=x86

--- a/driver/NVIDIA/DEPENDS
+++ b/driver/NVIDIA/DEPENDS
@@ -4,7 +4,8 @@ depends libXxf86vm
 depends libvdpau
 depends CUDA-OpenCL-headers
 depends libglvnd
+depends egl-wayland
 
 # Optional, to break circular dependency between gtk+-2 and nvidia
 optional_depends gtk+-3 "" "" "to build nvidia-settings"
-optional_depends gtk+-2 "" "" "to build nvidia-settings" y
+optional_depends gtk+-2 "" "" "to build nvidia-settings"

--- a/driver/NVIDIA/PRE_BUILD
+++ b/driver/NVIDIA/PRE_BUILD
@@ -16,3 +16,4 @@
     pkg-history.txt nvidia-installer{,.*}                  \
     mkprecompiled nvidia-xconfig{,.*} nvidia-settings{,.*} \
     tls_test* libGL.la gl*.h
+


### PR DESCRIPTION
…yland to DEPENDS

else a fix will kick a recompile on not finding egl-wayland.