### PR TITLE
encodings: version bumped to 1.0.6

### DIFF
--- a/font/encodings/DETAILS
+++ b/font/encodings/DETAILS
@@ -1,12 +1,12 @@
           MODULE=encodings
-         VERSION=1.0.5
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.0.6
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/font/
-      SOURCE_VFY=sha256:bd96e16143a044b19e87f217cf6a3763a70c561d1076aad6f6d862ec41774a31
+      SOURCE_VFY=sha256:77e301de661f35a622b18f60b555a7e7d8c4d5f43ed41410e830d5ac9084fc26
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://xorg.freedesktop.org/
          ENTERED=20070216
-         UPDATED=20191024
+         UPDATED=20220809
            SHORT="XOrg font encoding files"
 
 cat << EOF


### PR DESCRIPTION
Upstream changed from bz2 to xz for tarball compression. 
Also the gz format remains available.