### PR TITLE
font-util: version bumped to 1.3.3

### DIFF
--- a/font/font-util/DETAILS
+++ b/font/font-util/DETAILS
@@ -1,12 +1,12 @@
           MODULE=font-util
-         VERSION=1.3.2
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.3.3
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/font/
-      SOURCE_VFY=sha256:3ad880444123ac06a7238546fa38a2a6ad7f7e0cc3614de7e103863616522282
+      SOURCE_VFY=sha256:e791c890779c40056ab63aaed5e031bb6e2890a98418ca09c534e6261a2eebd2
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060120
-         UPDATED=20191018
+         UPDATED=20220809
            SHORT="X.Org font utilities"
 
 cat << EOF


### PR DESCRIPTION
Upstream went from bz2 to xz here too.