### PR TITLE
ico: version bumped to 1.0.6

### DIFF
--- a/app/ico/DETAILS
+++ b/app/ico/DETAILS
@@ -1,12 +1,12 @@
           MODULE=ico
-         VERSION=1.0.5
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.0.6
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/app/
-      SOURCE_VFY=sha256:d73b62f29eb98d850f16b76d759395180b860b613fbe1686b18eee99a6e3773f
+      SOURCE_VFY=sha256:38f369d431e753280fde70fa489cc94ce204f9f8eabd2f49fc7d32afa69f4405
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060302
-         UPDATED=20190812
+         UPDATED=20220908
            SHORT="Animate an icosahedron or other polyhedron"
 
 cat << EOF


### PR DESCRIPTION
Upstream changed compression from bz2 to xz.