### PR TITLE
showfont: version bumped to 1.0.6

### DIFF
--- a/app/showfont/DETAILS
+++ b/app/showfont/DETAILS
@@ -1,12 +1,12 @@
           MODULE=showfont
-         VERSION=1.0.5
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.0.6
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/app/
-      SOURCE_VFY=sha256:e9735c1c530b8a52edfab7415cc0fd7f8d2889095114f4cb689a27476461ac89
+      SOURCE_VFY=sha256:2b9b9f06e65e095ed76ce560b701b9fc47fa63310ee706b54c8787af061d0e56
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20080601
-         UPDATED=20180211
+         UPDATED=20220908
            SHORT="A font dumper for X font server"
 
 cat << EOF


### PR DESCRIPTION
Upstream changed compression from bz2 to xz.