### PR TITLE
xdg-utils: For some reason, I guess with recent updates xdg-utils needs

### DIFF
--- a/utils/xdg-utils/BUILD
+++ b/utils/xdg-utils/BUILD
@@ -1,3 +1,5 @@
+export XML_CATALOG_FILES=/etc/xml/catalog &&
+
 default_build &&
 
 mkdir -p /usr/share/applications /usr/share/mime /usr/share/desktop-directories


### PR DESCRIPTION
XML_CATALOG_FILES exported. This module also blew up for me and with this should fix https://github.com/lunar-linux/moonbase-xorg/issues/853.