### PR TITLE
imake: version bumped to 1.0.9

### DIFF
--- a/utils/imake/DETAILS
+++ b/utils/imake/DETAILS
@@ -1,12 +1,12 @@
           MODULE=imake
-         VERSION=1.0.8
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.0.9
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/util
-      SOURCE_VFY=sha256:b8d2e416b3f29cd6482bcffaaf19286d32917a164d07102a0e531ccd41a2a702
+      SOURCE_VFY=sha256:72de9d278f74d95d320ec7b0d745296f582264799eab908260dbea0ce8e08f83
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20061017
-         UPDATED=20190519
+         UPDATED=20221020
            SHORT="The X.Org C preprocessor-based Makefile build system"
 
 cat << EOF


### PR DESCRIPTION
Upstream changed from bz2 to xz, gz still available.