### PR TITLE
rgb: version bumped to 1.1.0

### DIFF
--- a/app/rgb/DETAILS
+++ b/app/rgb/DETAILS
@@ -1,12 +1,12 @@
           MODULE=rgb
-         VERSION=1.0.6
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.1.0
+          SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/app/
-      SOURCE_VFY=sha256:bbca7c6aa59939b9f6a0fb9fff15dfd62176420ffd4ae30c8d92a6a125fbe6b0
+      SOURCE_VFY=sha256:fc03d7f56e5b2a617668167f8927948cce54f93097e7ccd9f056077f479ed37b
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
          ENTERED=20060120
-         UPDATED=20180211
+         UPDATED=20221031
            SHORT="The X.Org GRB database and utilities"
 
 cat << EOF


### PR DESCRIPTION
Archive type also changed from bz2 to xz here.