### PR TITLE
xorg-sgml-doctools: version bumped to 1.12.1 + switch to meson

### DIFF
--- a/doc/xorg-sgml-doctools/BUILD
+++ b/doc/xorg-sgml-doctools/BUILD
@@ -1,3 +1,0 @@
-. /etc/profile.d/x11r7.rc &&
-
-default_build

--- a/doc/xorg-sgml-doctools/DETAILS
+++ b/doc/xorg-sgml-doctools/DETAILS
@@ -1,12 +1,13 @@
           MODULE=xorg-sgml-doctools
-         VERSION=1.12
-          SOURCE=$MODULE-$VERSION.tar.bz2
+         VERSION=1.12.1
+          SOURCE=$MODULE-$VERSION.tar.gz
       SOURCE_URL=$XORG_URL/individual/doc/
-      SOURCE_VFY=sha256:65a9fdddedc17bd5e9c0b00d904960f03f047c3a62de5458989d493c29fec806
+      SOURCE_VFY=sha256:8de3406f96a02bc3ab51ff47ba1612d9a11fc25d2edcaa06caa2cb2420d7bae0
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=http://www.x.org
+            TYPE=meson
          ENTERED=20070906
-         UPDATED=20220508
+         UPDATED=20240421
            SHORT="SGML entity definitions"
 
 cat << EOF

--- a/doc/xorg-sgml-doctools/PRE_BUILD
+++ b/doc/xorg-sgml-doctools/PRE_BUILD
@@ -1,0 +1,4 @@
+default_pre_build &&
+
+# Change the pkgconfig file location from /usr/share to /usr/lib
+sedit "s@\(install_dir:\) get.*@\1 '/usr/lib/pkgconfig',@" meson.build


### PR DESCRIPTION
The mailinglist email says that the autoconf build system will be removed in future releases, so switch to meson now.