### PR TITLE
libepoxy: add required deps (gegl, libglvnd and libX11)

### DIFF
--- a/lib/libepoxy/DEPENDS
+++ b/lib/libepoxy/DEPENDS
@@ -1,4 +1,7 @@
 depends meson
+depends gegl
+depends libglvnd
+depends libX11
 
 optional_depends doxygen \
                  "-D docs=true" \


### PR DESCRIPTION
/usr/include/epoxy/egl.h is required by xorg-server and is only generated when gegl is installed, so make it mandatory as well as libglvnd and libX11 as suggested by Ratler.