### PR TITLE
xorg-server: version bumped to 21.1.14 (security fix)

### DIFF
--- a/xorg-server/DETAILS
+++ b/xorg-server/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xorg-server
-         VERSION=21.1.13
+         VERSION=21.1.14
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/xserver
-     SOURCE_VFY=sha256:b45a02d5943f72236a360d3cc97e75134aa4f63039ff88c04686b508a3dc740c
+     SOURCE_VFY=sha256:8f2102cebdc4747d1656c1099ef610f5063c7422c24a177e300de569b354ee35
         WEB_SITE=http://www.x.org
          ENTERED=20060120
-         UPDATED=20240417
+         UPDATED=20241029
            SHORT="The X.Org X11R7 server for the X Window System"
 
 cat << EOF


### PR DESCRIPTION
Fixes CVE-2024-9632: Heap-based buffer overflow privilege escalation in _XkbSetCompatMap