### PR TITLE
xorg-server: add a missing dependency

### DIFF
--- a/xorg-server/DEPENDS
+++ b/xorg-server/DEPENDS
@@ -1,5 +1,6 @@
 depends libdmx
 depends libXaw
+depends libXdmcp
 depends libXt
 depends libXfont2
 depends libxkbui


### PR DESCRIPTION
So I'm testing the deployment of a graphical env in Qemu... the configuring fails with missing libXdmcp, so add it to the DEPENDS.