### PR TITLE
mesa-lib: fix first-time installs

### DIFF
--- a/lib/mesa-lib/POST_INSTALL
+++ b/lib/mesa-lib/POST_INSTALL
@@ -11,4 +11,9 @@ for mod in cairo libglvnd libva; do
   fi
 done
 
+# Take care of the missing epoxy/glx.h in xorg-server
+if [[ ! -e /usr/include/epoxy/glx.h ]]; then
+  lin -c libepoxy
+fi
+
 lin -c mesa-demos


### PR DESCRIPTION
This problem was found during a deployment test of a graphical env in a VM. The xorg-server module would fail with a missing epoxy/glx.h header, which comes from libepoxy being built with mesa-lib already installed.