### PR TITLE
xorg-server: version bumped to 21.1.18 + CVE fix

### DIFF
--- a/xorg-server/DETAILS
+++ b/xorg-server/DETAILS
@@ -1,11 +1,11 @@
           MODULE=xorg-server
-         VERSION=21.1.17
+         VERSION=21.1.18
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/xserver/
-      SOURCE_VFY=sha256:a29441c21a55f4cd2c2d93d3a4ec24a4c15f053d55aea104f97da32f66efecd0
+      SOURCE_VFY=sha256:c878d1930d87725d4a5bf498c24f4be8130d5b2646a9fd0f2994deff90116352
         WEB_SITE=http://www.x.org
          ENTERED=20060120
-         UPDATED=20250617
+         UPDATED=20250706
            SHORT="The X.Org X11R7 server for the X Window System"
 
 cat << EOF


### PR DESCRIPTION
Fixes [CVE-2025-49176](https://www.cvedetails.com/cve/CVE-2025-49176) (See https://lists.x.org/archives/xorg/2025-June/062055.html)