### PR TITLE
mesa-lib: Version bumped to 26.0.3

### DIFF
--- a/lib/mesa-lib/DETAILS
+++ b/lib/mesa-lib/DETAILS
@@ -1,13 +1,13 @@
-           MODULE=mesa-lib
-          VERSION=26.0.2
-           SOURCE=mesa-$VERSION.tar.xz
-       SOURCE_URL=https://archive.mesa3d.org
-       SOURCE_VFY=sha256:973f535221be211c6363842b4cce9ef8e9b3e1d5ea86c5450ca86060163c7346
- SOURCE_DIRECTORY=$BUILD_DIRECTORY/mesa-$VERSION
-         WEB_SITE=http://www.mesa3d.org
-          ENTERED=20060215
-          UPDATED=20260313
-            SHORT="Mesa 3D library"
+          MODULE=mesa-lib
+         VERSION=26.0.3
+          SOURCE=mesa-$VERSION.tar.xz
+      SOURCE_URL=https://archive.mesa3d.org
+      SOURCE_VFY=sha256:ddb7443d328e89aa45b4b6b80f077bf937f099daeca8ba48cabe32aab769e134
+SOURCE_DIRECTORY=$BUILD_DIRECTORY/mesa-$VERSION
+        WEB_SITE=http://www.mesa3d.org
+         ENTERED=20060215
+         UPDATED=20260319
+           SHORT="Mesa 3D library"
 
 cat << EOF
 Mesa is a 3-D graphics library with an API which is very similar to that of


### PR DESCRIPTION
Upgrade mesa-lib from 26.0.2 to 26.0.3

- Updated VERSION to 26.0.3
- Updated SOURCE_VFY to ddb7443d328e89aa45b4b6b80f077bf937f099daeca8ba48cabe32aab769e134
- Updated UPDATED date to 20260319

---
*Automated PR created by n8n + Claude AI*