### PR TITLE
mesa-lib: Version bumped to 26.0.5

### DIFF
--- a/lib/mesa-lib/DETAILS
+++ b/lib/mesa-lib/DETAILS
@@ -1,12 +1,12 @@
           MODULE=mesa-lib
-         VERSION=26.0.4
+         VERSION=26.0.5
           SOURCE=mesa-$VERSION.tar.xz
       SOURCE_URL=https://archive.mesa3d.org
-      SOURCE_VFY=sha256:6d91541e086f29bb003602d2c81070f2be4c0693a90b181ca91e46fa3953fe78
+      SOURCE_VFY=sha256:d229c9937d9a25ca0a8958c59f425174563d300ec42acbea2dbe84a055023368
 SOURCE_DIRECTORY=$BUILD_DIRECTORY/mesa-$VERSION
         WEB_SITE=http://www.mesa3d.org
          ENTERED=20060215
-         UPDATED=20260402
+         UPDATED=20260416
            SHORT="Mesa 3D library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade mesa-lib from 26.0.4 to 26.0.5

- Updated VERSION to 26.0.5
- Updated SOURCE_VFY to d229c9937d9a25ca0a8958c59f425174563d300ec42acbea2dbe84a055023368
- Updated UPDATED timestamp to 20260416

---
*Automated PR created by n8n + Claude AI*