### PR TITLE
libXpm: Version bumped to 3.5.19

### DIFF
--- a/lib/libXpm/DETAILS
+++ b/lib/libXpm/DETAILS
@@ -1,12 +1,12 @@
           MODULE=libXpm
-         VERSION=3.5.18
+         VERSION=3.5.19
           SOURCE=$MODULE-$VERSION.tar.xz
       SOURCE_URL=$XORG_URL/individual/lib/
-      SOURCE_VFY=sha256:b4ed79bfc718000edee837d551c35286f0b84576db0ce07bbbebe60a4affa1e4
+      SOURCE_VFY=sha256:ad3576d689221a39dc728f0e0dc02ca7bb6a0d724c9a77fd1bfa1e9af83be900
    MODULE_PREFIX=${X11R7_PREFIX:-/usr}
         WEB_SITE=https://www.x.org
          ENTERED=20060120
-         UPDATED=20260126
+         UPDATED=20260421
            SHORT="The X.Org pixmap library"
 
 cat << EOF


### PR DESCRIPTION
Upgrade libXpm from 3.5.18 to 3.5.19

- Updated VERSION to 3.5.19
- Updated SOURCE_VFY to ad3576d689221a39dc728f0e0dc02ca7bb6a0d724c9a77fd1bfa1e9af83be900
- Updated UPDATED timestamp to 20260421

---
*Automated PR created by n8n + Claude AI*